### PR TITLE
Add upload/download and stable option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # targets_storage
 
-This repository is meant to be a small vignette of the `AquaSat/AquaMatch_download_WQP` which documents some pain points in our use of {targets} with large data objects, especially regarding WQP. download, which is not static.
+This repository is meant to be a small vignette of the `AquaSat/AquaMatch_download_WQP` which documents some pain points in our use of {targets} with large data objects, especially regarding WQP download, which is not static.
 
 The `run.R` file contains the suggested workflow for running this pipeline. As of 2/16/2024, completion takes ~20 minutes.

--- a/_targets.R
+++ b/_targets.R
@@ -172,7 +172,7 @@ list(
   # the targets below:
   tar_target(
     name = data_version_stable,
-    command = TRUE
+    command = FALSE
   ),
   
   # Mimicking the purpose of a second repo, we read in the table containing

--- a/_targets.R
+++ b/_targets.R
@@ -191,6 +191,7 @@ list(
     read = read_csv(file = !!.x)
   ),
   
+  # Download the dataset to mimic pulling it into a second repository
   tar_target(
     name = chl_wqp_drive_download,
     command = retrieve_data(link_table = chl_wqp_data_link_in,

--- a/run.R
+++ b/run.R
@@ -31,12 +31,25 @@ lapply(required_pkgs, package_installer)
 
 # Load packages for use below
 library(targets)
+library(googledrive)
 
 
 # Directory handling ------------------------------------------------------
 
 # Check for directory and create if it doesn't exist
-if (!dir.exists("data/")) {dir.create("data/")}
+if (!dir.exists("data/in/")) {dir.create(path = "data/in/",
+                                         recursive = TRUE)}
+
+if (!dir.exists("data/out/")) {dir.create(path = "data/out/",
+                                          recursive = TRUE)}
+
+
+# Google Drive auth -------------------------------------------------------
+
+# Confirm Google Drive is authorized locally
+drive_auth()
+# Select existing account (change if starting from scratch)
+2
 
 
 # Run pipeline ------------------------------------------------------------


### PR DESCRIPTION
Hey B,

This PR adds in the {googledrive} components including upload of the fresh dataset and then downloading it, as though it was being brought into a new pipeline. I also added the option for a "stable" dataset. I opted to do this instead of the Google Sheets option we've been discussing so that the current method is documented as an example. Let me know if you think anything needs to be added! It should run as-is.