### PR TITLE
New Google Drive approach

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,11 @@
 
 # Data
 _targets/
-data/
+data/*
+!data/out/
+data/out/*
+!data/out/chl_stable_drive_ids.csv
+
 # Ignore data file types
 **.feather
 **.rds

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # targets_storage
 
-This repository is meant to be a small vignette of the `AquaSat/AquaMatch_download_WQP` which documents some pain points in our use of {targets} with large data objects, especially regarding WQP download, which is not static.
+This repository is meant to be a small vignette of the `AquaSat/AquaMatch_download_WQP` which 
+documents some pain points in our use of {targets} with large data objects, especially regarding WQP 
+download, which is not static. This architecture requires a google account to function, and one intends to 
+update the pipeline for the external world (aka, create stable datasets for downstream use, e.g. AquaSat), 
+you will need to authenticate using the ROSSyndicate google account.
 
 The `run.R` file contains the suggested workflow for running this pipeline. As of 2/16/2024, completion takes ~20 minutes.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # targets_storage
 
-This repository is meant to be a small vignette of the `AquaSat/AquaMatch_download_WQP` which documents some pain points in our use of {targets} with large data objects, especially regarding WQP. download, which is not static.
+This repository is meant to be a small vignette of the `AquaSat/AquaMatch_download_WQP` which documents some pain points in our use of {targets} with large data objects, especially regarding WQP download, which is not static.
 
 The `run.R` file contains the suggested workflow for running this pipeline. As of 2/16/2024, completion takes ~20 minutes.

--- a/_targets.R
+++ b/_targets.R
@@ -185,6 +185,7 @@ list(
                            drive_folder = "~/targets_storage_example/chlorophyll/stable/",
                            file_path = "data/out/chl_stable_drive_ids.csv",
                            recent = TRUE,
+                           stable_date = "20240223",
                            # Optional
                            depend = chl_wqp_data_file),
     read = read_csv(file = !!.x),

--- a/_targets.R
+++ b/_targets.R
@@ -172,7 +172,7 @@ list(
   # the targets below:
   tar_target(
     name = data_version_stable,
-    command = TRUE
+    command = FALSE
   ),
   
   # Mimicking the purpose of a second repo, we read in the table containing

--- a/_targets.R
+++ b/_targets.R
@@ -19,7 +19,7 @@ list(
   tar_target(
     name = workflow_config,
     # The config package does not like to be used with library()
-    command = config::get()
+    command = config::get(config = "admin_update")
   ),
   
   # The 

--- a/_targets.R
+++ b/_targets.R
@@ -17,7 +17,7 @@ list(
   
   # The CharacteristicNames we want to query
   tar_target(
-    name = wqp_characteristics,
+    name = chl_wqp_characteristics,
     command = c(
       "Chlorophyll a",
       "Chlorophyll a (probe relative fluorescence)",
@@ -42,6 +42,26 @@ list(
       startDateLo = "1970-01-01",
       startDateHi = Sys.Date()
     )
+  ),
+  
+  # CharacteristicNames and other query info can change over time, so it can
+  # be helpful to save a record of what we used for this run. We'll use
+  # {googledrive} to send these data away for storage after exporting as .rds,
+  # but document their location online in local csvs. But note that we
+  # won't be tagging any upload as a specific version in Google Drive; unless
+  # we manually copy it into the "stable" folder in Google Drive it will be
+  # overwritten by future pipeline runs.
+  
+  tar_target(
+    name = chl_wqp_characteristics_file,
+    command = export_single_file(target = chl_wqp_characteristics,
+                                 drive_path = "~/targets_storage_example/chlorophyll/")
+  ),
+  
+  tar_target(
+    name = wqp_args_file,
+    command = export_single_file(target = wqp_args,
+                                 drive_path = "~/targets_storage_example/chlorophyll/")
   ),
   
   # A grid to use for branching
@@ -85,10 +105,10 @@ list(
   tar_target(
     name = chl_inventory,
     command = take_inventory(grid_aoi = grid_aoi,
-                             wqp_characteristics = wqp_characteristics,
+                             wqp_characteristics = chl_wqp_characteristics,
                              wqp_args = wqp_args),
     # Each iteration is one grid cell x CharacteristicName combo
-    pattern = cross(grid_aoi, wqp_characteristics),
+    pattern = cross(grid_aoi, chl_wqp_characteristics),
     # Don't fail out if one branch errors
     error = "continue",
     packages = c("tidyverse", "retry", "sf", "dataRetrieval", "units")
@@ -113,7 +133,7 @@ list(
   # Break data into download groups based on record counts
   tar_target(
     name = chl_download_groups,
-    command = assign_download_groups(chl_site_counts = chl_site_counts),
+    command = assign_download_groups(site_counts = chl_site_counts),
     iteration = "group",
     packages = c("tidyverse", "MESS")
   ),
@@ -131,40 +151,13 @@ list(
     packages = c("dataRetrieval", "tidyverse", "sf", "retry")
   ),
   
-  # Use {googledrive} to send this large data file away for storage but document
-  # its location online in a local csv. The goal of this is to mimic the way
-  # that large files may be uploaded to Google Drive for storage, (potential)
-  # versioning, and transfer between pipelines. Note that it also produces a
-  # local .rds file for uploading.
-  tar_file(
+  # Use {googledrive} to send this large data file away for storage. The goal
+  # of this is to mimic the way that large files may be uploaded to Google Drive
+  # for storage, (potential) versioning, and transfer between pipelines.
+  tar_target(
     name = chl_wqp_data_link_file,
     command = export_single_file(target = chl_wqp_data,
-                                 folder_pattern = "data/out/")
-  ),
-  
-  # If this dataset has been previously downloaded, then there's the option to
-  # use a prior version instead of the dynamically downloaded one above. This
-  # target adds the metadata necessary for this to be used in the rest of the
-  # workflow to a table to store in a local csv.
-  tar_file(
-    name = chl_wqp_data_link_file_stable,
-    command = {
-      
-      # Where to store the csv with link info
-      out_path <- "data/out/chl_wqp_data_out_link_stable.csv"
-      
-      stable_drive_link <- tribble(
-        ~dataset, ~local_path, ~drive_link,
-        "p2_site_counts_chl", "data/out/chl_wqp_data.rds", "https://drive.google.com/file/d/1krSVWZ6U5A8eNaDd-FZUD8K2AzYH6rRX/view?usp=sharing"
-      )
-      
-      # Export the csv
-      write_csv(x = stable_drive_link, file = out_path)
-      
-      # Return path to pipeline
-      out_path
-      
-    }
+                                 drive_path = "~/targets_storage_example/chlorophyll/")
   ),
   
   # Here we choose whether we want a stable version of the `chl_wqp_data`
@@ -172,30 +165,19 @@ list(
   # the targets below:
   tar_target(
     name = data_version_stable,
-    command = FALSE
+    command = TRUE
   ),
   
-  # Mimicking the purpose of a second repo, we read in the table containing
-  # the link from the export above. If a stable version is requested then
-  # we get the download link for the stable dataset defined above
-  tar_file_read(
-    name = chl_wqp_data_link_in,
-    command = {
-      if(data_version_stable){
-        chl_wqp_data_link_file_stable
-      } else {
-        chl_wqp_data_link_file
-      }
-    },
-    cue = tar_cue("always"),
-    read = read_csv(file = !!.x)
-  ),
-  
-  # Download the dataset to mimic pulling it into a second repository
+  # Mimicking the role of a second (e.g., harmonization) repo, we will download
+  # the dataset that we exported above. If a stable version is requested
+  # (i.e, data_version_stable == TRUE) the we download the target from the
+  # stable folder on Google Drive.
   tar_target(
-    name = chl_wqp_drive_download,
-    command = retrieve_data(link_table = chl_wqp_data_link_in,
-                            folder_pattern = "data/in/"),
+    name = chl_wqp_data_in,
+    command = retrieve_data(local_folder = "data/in/",
+                            drive_folder = "~/targets_storage_example/chlorophyll/",
+                            target = chl_wqp_data,
+                            stable = data_version_stable),
     packages = c("tidyverse", "googledrive")
   )
   

--- a/_targets.R
+++ b/_targets.R
@@ -191,6 +191,7 @@ list(
     read = read_csv(file = !!.x)
   ),
   
+  # Download the dataset to mimic pulling it into a second repository
   tar_target(
     name = chl_wqp_drive_download,
     command = retrieve_data(link_table = chl_wqp_data_link_in,

--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,12 @@
-default:
+use_stable_links:
+   google_email: ""
+   chl_stable: TRUE
+   chl_create_stable: FALSE
+create_new_version:
+   google_email: ""
+   chl_stable: FALSE
+   chl_create_stable: FALSE
+admin_update:
   google_email: "therossyndicate@gmail.com"
   # Use a stable version of the chlorophyll data?
   chl_stable: FALSE

--- a/config.yml
+++ b/config.yml
@@ -1,5 +1,5 @@
-use_stable_links:
-   google_email: ""
+default:
+   google_email: "therossyndicate@gmail.com"
    chl_stable: TRUE
    chl_create_stable: FALSE
 create_new_version:

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,6 @@
+default:
+  google_email: "therossyndicate@gmail.com"
+  # Use a stable version of the chlorophyll data?
+  chl_stable: FALSE
+  # Create a stable version of chlorophyll data from this run?
+  chl_create_stable: TRUE

--- a/data/out/chl_stable_drive_ids.csv
+++ b/data/out/chl_stable_drive_ids.csv
@@ -1,0 +1,4 @@
+name,id
+chl_wqp_data_20240222.rds,1I3MYl6EpGHGUuQ2gT5L52qt_V2m45MIU
+chl_wqp_characteristics_20240222.rds,1XSVUzDxrJ4n4vgO3bivCrwNhaM41viFy
+wqp_args_20240222.rds,11hRPhToJ1LYso3-xToYEFuntvK5MlDx4

--- a/run.R
+++ b/run.R
@@ -46,7 +46,11 @@ if (!dir.exists("data/out/")) {dir.create(path = "data/out/",
 
 # Google Drive auth -------------------------------------------------------
 
-# Confirm Google Drive is authorized locally
+# Confirm Google Drive is authorized locally. If you are a member of the AquaSat team and 
+# are updating the stable version of the pipeline, you will need to authorize Google using
+# the ROSSyndicate gmail account. All other users can use any google address, allowing 
+# for their personal 'version' of the data download for use throughout the remainder of the
+# pipeline.
 drive_auth()
 # Select existing account (change if starting from scratch)
 2

--- a/run.R
+++ b/run.R
@@ -57,6 +57,15 @@ drive_auth()
 2
 
 
-# Run pipeline ------------------------------------------------------------
+# There are a few options for running this pipeline, and you will need to assure that your Google email has been added in the `config.yml` file. 
+
+# create a fresh version of all {targets} - make sure that line 22 in `_targets.R` is set to "create_new_version"
+tar_make()
+
+#  just load the stable version from AquaSat - make sure that line 22 in `_targets.R` is set to "use_stable_link"
+tar_make(chl_wqp_data_in)
+
+# members of the AquaSat team can update the stable version using "admin_update" on line 22 in `_targets.R`
+tar_make()
 
 tar_make()

--- a/run.R
+++ b/run.R
@@ -4,6 +4,7 @@
 
 # List of packages required for this pipeline
 required_pkgs <- c(
+  "config",
   "dataRetrieval",
   "feather",
   "googledrive",
@@ -26,7 +27,7 @@ package_installer <- function(x) {
   }
 }
 
-# map function using base lapply
+# Iterate through package installs using base lapply
 lapply(required_pkgs, package_installer)
 
 # Load packages for use below

--- a/run.R
+++ b/run.R
@@ -31,12 +31,25 @@ lapply(required_pkgs, package_installer)
 
 # Load packages for use below
 library(targets)
+library(googledrive)
 
 
 # Directory handling ------------------------------------------------------
 
 # Check for directory and create if it doesn't exist
-if (!dir.exists("data/")) {dir.create("data/")}
+if (!dir.exists("data/in/")) {dir.create(path = "data/in/",
+                                         recursive = TRUE)}
+
+if (!dir.exists("data/out/")) {dir.create(path = "data/out/",
+                                          recursive = TRUE)}
+
+
+# Google Drive auth -------------------------------------------------------
+
+# Confirm Google Drive is authorized locally
+drive_auth()
+# Select existing account (change if starting from scratch)
+2
 
 
 # Run pipeline ------------------------------------------------------------

--- a/src/functions.R
+++ b/src/functions.R
@@ -313,7 +313,7 @@ export_single_file <- function(target, drive_path, stable, google_email){
                         name = paste0(target_string, ".rds"))
   
   # Make the Google Drive link shareable: anyone can view
-  drive_share(out_file, role = "reader", type = "anyone")
+  drive_share_anyone(out_file)
   
   # If stable == TRUE then export a second, dated file to the stable/ subfolder
   if(stable){
@@ -347,10 +347,10 @@ export_single_file <- function(target, drive_path, stable, google_email){
 #' A function to retrieve a dataset from Google Drive after it has been uploaded
 #' in a previous step.
 #' 
-#' @param target The name of the target to be exported (as an object not a string).
+#' @param target The name of the target to be retreived (as an object not a string).
 #' 
 #' @param local_folder A string specifying the folder where the file should be
-#' downloaded.
+#' downloaded to.
 #' 
 #' @param drive_folder A string specifying the folder location on Google Drive
 #' containing the file to be downloaded.

--- a/src/functions.R
+++ b/src/functions.R
@@ -288,7 +288,8 @@ fetch_wqp_data <- function(site_counts_grouped, char_names, wqp_args = NULL,
 #' 
 export_single_file <- function(target, drive_path){
   
-  require(googledrive)
+  # authorize using the google email provided
+  drive_auth(google_email)
   
   # Get target name as a string
   target_string <- deparse(substitute(target))
@@ -308,7 +309,7 @@ export_single_file <- function(target, drive_path){
                         name = paste0(target_string, ".rds"))
   
   # Make the Google Drive link shareable: anyone can view
-  out_file_share <- out_file %>%
+drive_share(out_file, role = "reader", type = "anyone")
     drive_share(role = "reader", type = "anyone")
   
   # Now remove the local file after upload is complete
@@ -340,7 +341,8 @@ export_single_file <- function(target, drive_path){
 #' 
 retrieve_data <- function(target, local_folder, drive_folder, stable, file_type = ".rds"){
   
-  require(googledrive)
+  # authorize using the google email provided
+  drive_auth(google_email)
   
   # Get target name as a string
   target_string <- paste0(deparse(substitute(target)), file_type)


### PR DESCRIPTION
Hey B,

What I've done here is to change the Google Drive integration so that files are stored and referenced using folders within Google Drive instead of individual links. I think you suggested this last week, but I forget exactly. Let me know if anything feels underdeveloped or would be difficult to pass between repositories. For example, I'm not sure how best to reference the Google Drive when jumping between repos: Should there be a single link to the overall Drive folder shared between repos, or does it not matter if the users of the second repo have ROSSyndicate Drive access? (Meaning we assume they do and so don't provide any reference link for downloading). "Stable" versions are also a part of this and I updated function documentation.

@matthewross07 if you're interested in trying this workflow out for yourself either now or after this is merged, here's basically how it works:
- A WQP inventory is done using chlorophyll `CharacteristicNames`, an AOI, and a grid intersecting that AOI
- Records per site are counted and used to group the data into appropriately-sized chunks for WQP queries
- Chlorophyll data are downloaded
- The chlorophyll downloads and query arguments are exported to Google Drive. The dataset (not queries) are then downloaded from there to test their portability